### PR TITLE
Implement accuracy improvements

### DIFF
--- a/src/delta5interface/BaseHardwareInterface.py
+++ b/src/delta5interface/BaseHardwareInterface.py
@@ -8,6 +8,7 @@ class BaseHardwareInterface(object):
         self.calibration_offset = 10
         self.trigger_threshold = 20
         self.start_time = datetime.now()
+        self.filter_ratio = 50
 
     # returns the elapsed milliseconds since the start of the program
     def milliseconds(self):
@@ -24,7 +25,8 @@ class BaseHardwareInterface(object):
             'nodes': [node.get_settings_json() for node in self.nodes],
             'calibration_threshold': self.calibration_threshold,
             'calibration_offset': self.calibration_offset,
-            'trigger_threshold': self.trigger_threshold
+            'trigger_threshold': self.trigger_threshold,
+            'filter_ratio': self.filter_ratio
         }
 
     def get_heartbeat_json(self):
@@ -46,6 +48,11 @@ class BaseHardwareInterface(object):
     def get_trigger_threshold_json(self):
         return {
             'trigger_threshold': self.trigger_threshold
+        }
+
+    def get_filter_ratio_json(self):
+        return {
+            'filter_ratio': self.filter_ratio
         }
 
     def get_frequency_json(self, node_index):

--- a/src/delta5interface/Delta5Interface.py
+++ b/src/delta5interface/Delta5Interface.py
@@ -14,16 +14,18 @@ READ_CALIBRATION_THRESHOLD = 0x15
 READ_CALIBRATION_MODE = 0x16
 READ_CALIBRATION_OFFSET = 0x17
 READ_TRIGGER_THRESHOLD = 0x18
+READ_FILTER_RATIO = 0x19
 
 WRITE_FREQUENCY = 0x51 # Sets frequency (2 byte)
 WRITE_CALIBRATION_THRESHOLD = 0x65
 WRITE_CALIBRATION_MODE = 0x66
 WRITE_CALIBRATION_OFFSET = 0x67
 WRITE_TRIGGER_THRESHOLD = 0x68
+WRITE_FILTER_RATIO = 0x69
 
-UPDATE_SLEEP = 0.01 # Main update loop delay
+UPDATE_SLEEP = 0.1 # Main update loop delay
 
-I2C_CHILL_TIME = 0.075 # Delay after i2c read/write
+I2C_CHILL_TIME = 0.05 # Delay after i2c read/write
 I2C_RETRY_COUNT = 5 # Limit of i2c retries
 
 def unpack_8(data):
@@ -96,10 +98,13 @@ class Delta5Interface(BaseHardwareInterface):
                     READ_CALIBRATION_OFFSET)
                 self.trigger_threshold = self.get_value_16(node,
                     READ_TRIGGER_THRESHOLD)
+                self.filter_ratio = self.get_value_8(node,
+                    READ_FILTER_RATIO)
             else:
                 self.set_calibration_threshold(node.index, self.calibration_threshold)
                 self.set_calibration_offset(node.index, self.calibration_offset)
                 self.set_trigger_threshold(node.index, self.trigger_threshold)
+
 
     #
     # Class Functions
@@ -310,6 +315,19 @@ class Delta5Interface(BaseHardwareInterface):
         for node in self.nodes:
             self.set_trigger_threshold(node.index, threshold)
         return self.trigger_threshold
+
+    def set_filter_ratio(self, node_index, filter_ration):
+        node = self.nodes[node_index]
+        node.filter_ration = self.set_and_validate_value_8(node,
+            WRITE_FILTER_RATIO,
+            READ_FILTER_RATIO,
+            filter_ration)
+
+    def set_filter_ratio_global(self, filter_ratio):
+        self.filter_ratio = filter_ratio
+        for node in self.nodes:
+            self.set_filter_ratio(node.index, filter_ratio)
+        return self.filter_ratio
 
 def get_hardware_interface():
     '''Returns the delta 5 interface object.'''

--- a/src/delta5node/delta5node.ino
+++ b/src/delta5node/delta5node.ino
@@ -30,7 +30,7 @@
 // Node Setup -- Set the i2c address here
 // Node 1 = 8, Node 2 = 10, Node 3 = 12, Node 4 = 14
 // Node 5 = 16, Node 6 = 18, Node 7 = 20, Node 8 = 22
-#define i2cSlaveAddress 16
+#define i2cSlaveAddress 8
 
 const int slaveSelectPin = 10; // Setup data pins for rx5808 comms
 const int spiDataPin = 11;

--- a/src/delta5node/delta5node.ino
+++ b/src/delta5node/delta5node.ino
@@ -60,7 +60,7 @@ struct {
 	uint16_t volatile calibrationThreshold = 95;
 	// Rssi must fall below trigger - settings.triggerThreshold to end a normal pass
 	uint16_t volatile triggerThreshold = 40;
-	uint8_t volatile filterRatio = 50;
+	uint8_t volatile filterRatio = 10;
 	float volatile filterRatioFloat = 0.0f;
 } settings;
 

--- a/src/delta5node/delta5node.ino
+++ b/src/delta5node/delta5node.ino
@@ -30,7 +30,7 @@
 // Node Setup -- Set the i2c address here
 // Node 1 = 8, Node 2 = 10, Node 3 = 12, Node 4 = 14
 // Node 5 = 16, Node 6 = 18, Node 7 = 20, Node 8 = 22
-#define i2cSlaveAddress 8
+#define i2cSlaveAddress 16
 
 const int slaveSelectPin = 10; // Setup data pins for rx5808 comms
 const int spiDataPin = 11;
@@ -43,21 +43,25 @@ const int spiClockPin = 13;
 #define READ_CALIBRATION_MODE 0x16
 #define READ_CALIBRATION_OFFSET 0x17
 #define READ_TRIGGER_THRESHOLD 0x18
+#define READ_FILTER_RATIO 0x19
 
 #define WRITE_FREQUENCY 0x51
 #define WRITE_CALIBRATION_THRESHOLD 0x65
 #define WRITE_CALIBRATION_MODE 0x66
 #define WRITE_CALIBRATION_OFFSET 0x67
 #define WRITE_TRIGGER_THRESHOLD 0x68
+#define WRITE_FILTER_RATIO 0x69
 
 struct {
 	uint16_t volatile vtxFreq = 5800;
 	// Subtracted from the peak rssi during a calibration pass to determine the trigger value
-	uint16_t volatile calibrationOffset = 5;
+	uint16_t volatile calibrationOffset = 8;
 	// Rssi must fall below trigger - settings.calibrationThreshold to end a calibration pass
-	uint16_t volatile calibrationThreshold = 60;
+	uint16_t volatile calibrationThreshold = 95;
 	// Rssi must fall below trigger - settings.triggerThreshold to end a normal pass
-	uint16_t volatile triggerThreshold = 30;
+	uint16_t volatile triggerThreshold = 40;
+	uint8_t volatile filterRatio = 50;
+	float volatile filterRatioFloat = 0.0f;
 } settings;
 
 struct {
@@ -140,6 +144,7 @@ void setup() {
     cbi(ADCSRA,ADPS0);
 
 	// Initialize lastPass defaults
+	settings.filterRatioFloat = settings.filterRatio / 1000.0f;
 	state.rssi = 0;
 	state.rssiTrigger = 0;
 	lastPass.rssiPeakRaw = 0;
@@ -247,17 +252,10 @@ void setRxModule(int frequency) {
 	digitalWrite(spiDataPin, LOW);
 }
 
-#define RSSI_READ_AVERAGE_COUNT 10
 
 // Read the RSSI value for the current channel
 int rssiRead() {
-	long rssiAvg = 0; // Calculate rssi average
-	for (uint8_t i = 0; i < RSSI_READ_AVERAGE_COUNT; i++){
-		rssiAvg += analogRead(0); // Pin A0
-	}
-	rssiAvg = (int) (rssiAvg / RSSI_READ_AVERAGE_COUNT); // Average of 50 rssi readings
-	rssiAvg = constrain(rssiAvg, 1, 32000); // Positive 2 byte limit, not really needed
-	return rssiAvg;
+	return analogRead(0);
 }
 
 // Main loop
@@ -265,14 +263,12 @@ void loop() {
 	//delay(250);
 
 	// Calculate the time it takes to run the main loop
-	int lastLoopTimeStamp = state.lastLoopTimeStamp;
+	uint32_t lastLoopTimeStamp = state.lastLoopTimeStamp;
 	state.lastLoopTimeStamp = micros();
 	state.loopTime = state.lastLoopTimeStamp - lastLoopTimeStamp;
 
-	const float filterRatio =  0.01f;
-
 	state.rssiRaw = rssiRead();
-	state.rssiSmoothed = (filterRatio * (float)state.rssiRaw) + ((1.0f-filterRatio) * state.rssiSmoothed);
+	state.rssiSmoothed = (settings.filterRatioFloat * (float)state.rssiRaw) + ((1.0f-settings.filterRatioFloat) * state.rssiSmoothed);
 	state.rssi = (int)state.rssiSmoothed;
 
 	if (state.rssiTrigger > 0) {
@@ -300,8 +296,10 @@ void loop() {
 
 			state.rssiPeak = max(state.rssiPeak, state.rssi);
 
+			// Make sure the threshold does not put the trigger below 0 RSSI
 			// See if we have left the gate
-			if (state.rssi < (state.rssiTrigger - triggerThreshold)) {
+			if ((state.rssiTrigger > triggerThreshold) &&
+				(state.rssi < (state.rssiTrigger - triggerThreshold))) {
 				Serial.println("Crossing = False");
 				lastPass.rssiPeakRaw = state.rssiPeakRaw;
 				lastPass.rssiPeak = state.rssiPeak;
@@ -466,6 +464,13 @@ byte i2cHandleRx(byte command) { // The first byte sent by the I2C master is the
 				success = true;
 			}
 			break;
+		case WRITE_FILTER_RATIO:
+			if (readAndValidateIoBuffer(WRITE_FILTER_RATIO, 1)) {
+				settings.filterRatio = ioBufferRead8();
+				settings.filterRatioFloat =  settings.filterRatio / 1000.0f;
+				success = true;
+			}
+			break;
 	}
 
 	ioCommand = 0; // Clear previous command
@@ -510,6 +515,9 @@ void i2cTransmit() {
 			break;
 		case READ_TRIGGER_THRESHOLD:
 			ioBufferWrite16(settings.triggerThreshold);
+			break;
+		case READ_FILTER_RATIO:
+			ioBufferWrite8(settings.filterRatio);
 			break;
 		default: // If an invalid command is sent, write nothing back, master must react
 			Serial.print("TX Fault command: ");

--- a/src/timingserver/MockInterface.py
+++ b/src/timingserver/MockInterface.py
@@ -49,6 +49,9 @@ class MockInterface(BaseHardwareInterface):
     def set_trigger_threshold_global(self, trigger_threshold):
         self.trigger_threshold = trigger_threshold
 
+    def set_filter_ratio_global(self, filter_ratio):
+        self.filter_ratio = filter_ratio
+
     def set_calibration_mode(self, node_index, calibration_mode):
         pass
 

--- a/src/timingserver/server.py
+++ b/src/timingserver/server.py
@@ -114,6 +114,14 @@ def on_set_trigger_threshold(data):
     hardwareInterface.set_trigger_threshold_global(trigger_threshold)
     emit('trigger_threshold_set', hardwareInterface.get_trigger_threshold_json(), broadcast=True)
 
+@socketio.on('set_filter_ratio')
+def on_set_filter_ratio(data):
+    data = parse_json(data)
+    print(data)
+    filter_ratio = data['filter_ratio']
+    hardwareInterface.set_filter_ratio_global(filter_ratio)
+    emit('filter_ratio_set', hardwareInterface.get_filter_ratio_json(), broadcast=True)
+
 # Keep this around for a bit.. old version of the api
 # @socketio.on('reset_auto_calibration')
 # def on_reset_auto_calibration():

--- a/src/timingserver/templates/index.html
+++ b/src/timingserver/templates/index.html
@@ -22,6 +22,7 @@
             var socket = io.connect(location.protocol + '//' + document.domain + ':' + location.port);
 
             var num_nodes = 0;
+            var start_timestamp = [];
             var last_lap_timestamp = [];
 
             function map_range(in_min, in_max, out_min, out_max, value) {
@@ -64,8 +65,10 @@
                     append_to_log('get_timestamp returned ' + JSON.stringify(msg));
 
                     last_lap_timestamp = [];
+                    start_timestamp = [];
                     for (i=0; i<num_nodes; i++) {
                         last_lap_timestamp.push(msg.timestamp);
+                        start_timestamp.push(msg.timestamp);
                     }
                 });
                 return false;
@@ -135,6 +138,14 @@
                 return false;
             });
 
+            $('form#set_filter_ratio').submit(function() {
+                var data = {
+                    filter_ratio: parseInt($('#filter_ratio_value').val())
+                }
+                socket.emit('set_filter_ratio', data);
+                return false;
+            });
+
             socket.emit('get_settings', function(msg) {
                 const Node = ({frequency, current_rssi, trigger_rssi}, index) => `
                     <div class='col-md-2'>
@@ -193,6 +204,7 @@
                 $('#calibration_threshold_value').val(msg.calibration_threshold);
                 $('#calibration_offset_value').val(msg.calibration_offset);
                 $('#trigger_threshold_value').val(msg.trigger_threshold);
+                $('#filter_ratio_value').val(msg.filter_ratio);
 
                 append_to_log('get_settings returned ' + JSON.stringify(msg));
 
@@ -224,6 +236,11 @@
                 append_to_log('on trigger_threshold_set ' + JSON.stringify(msg));
             });
 
+            socket.on('filter_ratio_set', function(msg) {
+                $('#filter_ratio_value').val(msg.filter_ratio);
+                append_to_log('on filter_ratio_set ' + JSON.stringify(msg));
+            });
+
             function ms_to_time(s) {
               // Pad to 2 or 3 digits, default is 2
               function pad(n, z) {
@@ -243,17 +260,19 @@
             socket.on('pass_record', function(msg) {
                 buzzer.play();
                 var lap_table = $('#lap_table_' + msg.node);
-                const Lap = (index, rssi, time) => `
+                const Lap = (index, rssi, time_lap, time_total) => `
                     <tr>
                         <td>${index}</td>
-                        <td>${rssi}</td>
-                        <td><p class="text-right">${time}</p></td>
+                        <!--td>${rssi}</td-->
+                        <td><p class="text-right">${time_lap}</p></td>
+                        <td><p class="text-right">${time_total}</p></td>
                     </tr>
                 `;
 
-                var lap_time = msg.timestamp - last_lap_timestamp[msg.node];
+                var time_lap = msg.timestamp - last_lap_timestamp[msg.node];
+                var time_total = msg.timestamp - start_timestamp[msg.node];
                 last_lap_timestamp[msg.node] = msg.timestamp;
-                lap_table.append(Lap(lap_table[0].children.length, msg.peak_rssi, ms_to_time(lap_time)));
+                lap_table.append(Lap(lap_table[0].children.length, msg.peak_rssi, ms_to_time(time_lap), ms_to_time(time_total)));
                 append_to_log('on pass_record ' + JSON.stringify(msg));
 
                 $('#peak_rssi_' + msg.node).html(msg.peak_rssi);
@@ -303,6 +322,18 @@
                                 Trigger Threshold
                                 <div class="input-group input-group-sm">
                                     <input class="form-control" type="text" name="trigger_threshold_value" id="trigger_threshold_value" value='0'>
+                                    <span class="input-group-btn">
+                                        <input class="btn btn-default" type="submit" value="Set">
+                                    </span>
+                                </div>
+                            </div>
+                        </form>
+
+                        <form id="set_filter_ratio" method="POST" action='#'>
+                            <div class="form-group">
+                                Filter Ratio
+                                <div class="input-group input-group-sm">
+                                    <input class="form-control" type="text" name="filter_ratio_value" id="filter_ratio_value" value='0'>
                                     <span class="input-group-btn">
                                         <input class="btn btn-default" type="submit" value="Set">
                                     </span>


### PR DESCRIPTION
Since the exponentiation filtering works pretty good, i removed the averaging of the RSSI per read.  This drops the loop time to around 68-100us for a 10kHz update rate.  

I added a setting to change the filter ratio, not really intended to be a user facing thing but helpful for dialing in on the right value.  The value is divided by 1000, so a value of 10 means 0.01 or 1% new data vs 99% old data.   Higher values, probably don't want to go over 100, makes the filtered rssi more responsive at the expense of more noise.  I found 50 to work well outdoors and 10 to work good with whoops indoors.  We should play with this and come up with a good number to stick with.  For an idea of time, a value of 100 would make the filtered rssi take ~23ms to move from 100 - 200 if it was to jump instantly.  A value of 10 would take only ~1ms, but there would be more noise in the filtered value.

I also dropped the wait time for the i2c read/writes.  @scottgchin and @howflyquad, can you guys give this a shot?  I get very few IO errors where it is set in this commit.

I also changed the default tuning parameters to values that i found to work better for both outdoors and indoors.  I'm open to input on those.