### PR TITLE
Send initial profile values to nodes at startup

### DIFF
--- a/src/delta5server/server.py
+++ b/src/delta5server/server.py
@@ -1007,6 +1007,13 @@ if not os.path.exists('database.db'):
 # DB session commit needed to prevent 'application context' errors
 db_reset_current_laps()
 
+# Send initial profile values to nodes
+last_profile = LastProfile.query.get(1)
+tune_val = Profiles.query.get(last_profile.profile_id)
+INTERFACE.set_calibration_threshold_global(tune_val.c_threshold)
+INTERFACE.set_calibration_offset_global(tune_val.c_offset)
+INTERFACE.set_trigger_threshold_global(tune_val.t_threshold)
+
 
 # Test data - Current laps
 # DB.session.add(CurrentLap(node_index=2, pilot_id=2, lap_id=0, lap_time_stamp=1000, lap_time=1000, lap_time_formatted=time_format(1000)))


### PR DESCRIPTION
This modifies the 'delta5server' to send the calibration_threshold / calibration_offset / trigger_threshold values for the current profile in the database out to the nodes when the server starts up.  The way it is currently, the values are only sent when a value is changed or a different profile is selected, so the nodes can be at their default values (8/95/40) while the Settings page shows different values.

This was really messing me up until I figured out what was happening; I expect it is also causing trouble for others.

--ET