### PR TITLE
Add buttons for speaking pilot phonetic-names on Settings page

### DIFF
--- a/src/delta5server/server.py
+++ b/src/delta5server/server.py
@@ -342,6 +342,14 @@ def on_set_pilot_name(data):
     server_log('Pilot name set: Pilot {0} Name {1}'.format(pilot_id, name))
     emit_pilot_data() # Settings page, new pilot name
 
+@SOCKET_IO.on('speak_pilot')
+def on_speak_pilot(data):
+    '''Speaks the phonetic name of the pilot.'''
+    pilot_id = data['pilot_id']
+    phtext = Pilot.query.filter_by(pilot_id=pilot_id).first().phonetic
+    emit_phonetic_text(phtext)
+    server_log('Speak pilot: {0}'.format(phtext))
+
 @SOCKET_IO.on('add_profile')
 def on_add_profile():
     '''Adds new profile in the database.'''
@@ -765,6 +773,10 @@ def emit_current_fix_race_time():
     ''' Emit current fixed time race time '''
     race_time_sec = FixTimeRace.query.get(1).race_time_sec
     SOCKET_IO.emit('set_fix_race_time',{ fix_race_time: race_time_sec})
+
+def emit_phonetic_text(phtext):
+    '''Emits given phonetic text.'''
+    SOCKET_IO.emit('speak_phonetic_text', {'text': phtext})
 
 #
 # Program Functions

--- a/src/delta5server/templates/settings.html
+++ b/src/delta5server/templates/settings.html
@@ -114,8 +114,14 @@
 		
 		socket.on('language_data', function (msg) {
 			var $langid = msg.language;
+			sellang = $langid;
 			voice_label($langid);
 		});
+
+		socket.on('speak_phonetic_text', function (msg) {
+			var $ttstext = msg.text;
+			speak('<div class="speech">' + $ttstext + '</div> div.speech');				
+		})
 		
 		$('.set_frequency li a').click(function (event) {
 			var data = {
@@ -217,6 +223,14 @@
 			// document.getElementById("heats").innerHTML = // jinja template include
 			return false;
 		});
+		$('button#speak_pilot').click(function (event) {
+			var data = {
+				pilot_id: parseInt($(this).data('pilot_id')),
+				phonetic: $(this).val()
+			};
+			socket.emit('speak_pilot', data);
+			return false;
+		});
 		$('button#add_profile').click(function (event) {
 			socket.emit('add_profile');
 			window.location.href = "/settings"; // Update to not need page reload
@@ -261,6 +275,77 @@
 		})
 
 	});
+
+	var sellang = {{ lang_id }};
+
+	function speak(obj) {
+		switch (sellang) {
+			case 1:
+				$(obj).articulate('setVoice','name','Microsoft David Desktop - English (United States)').articulate('speak');
+				break;
+			case 2:
+				$(obj).articulate('setVoice','name','Microsoft Zira Desktop - English (United States)').articulate('speak');
+				break;
+			case 3:
+				$(obj).articulate('setVoice','name','Google US English').articulate('speak');
+				break;
+			case 4:
+				$(obj).articulate('setVoice','name','Google UK English Female').articulate('speak');
+				break;
+			case 5:
+				$(obj).articulate('setVoice','name','Google UK English Male').articulate('speak');
+				break;
+			case 6:
+				$(obj).articulate('setVoice','name','Google Deutsch').articulate('speak');
+				break;			
+			case 7:
+				$(obj).articulate('setVoice','name','Google español').articulate('speak');
+				break;
+			case 8:
+				$(obj).articulate('setVoice','name','Google español de Estados Unidos').articulate('speak');
+				break;
+			case 9:
+				$(obj).articulate('setVoice','name','Google français').articulate('speak');
+				break;
+			case 10:
+				$(obj).articulate('setVoice','name','Google हिन्दी').articulate('speak');
+				break;
+			case 11:
+				$(obj).articulate('setVoice','name','Google Bahasa Indonesia').articulate('speak');
+				break;
+			case 12:
+				$(obj).articulate('setVoice','name','Google italiano').articulate('speak');
+				break;
+			case 13:
+				$(obj).articulate('setVoice','name','Google 日本語').articulate('speak');
+				break;
+			case 14:
+				$(obj).articulate('setVoice','name','Google 한국의').articulate('speak');
+				break;
+			case 15:
+				$(obj).articulate('setVoice','name','Google Nederlands').articulate('speak');
+				break;
+			case 16:
+				$(obj).articulate('setVoice','name','Google polski').articulate('speak');
+				break;
+			case 17:
+				$(obj).articulate('setVoice','name','Google português do Brasil').articulate('speak');
+				break;
+			case 18:
+				$(obj).articulate('setVoice','name','Google русский').articulate('speak');
+				break;
+			case 19:
+				$(obj).articulate('setVoice','name','Google 國語（臺灣）').articulate('speak');
+				break;
+		}
+	};
+
+	function ratenormal(obj) {
+		$(obj).articulate('rate', 1.0);
+	};
+	function ratefast(obj) {
+		$(obj).articulate('rate', 3.0);
+	};
 
 </script>
 {% endblock %} {% block content %}
@@ -371,6 +456,7 @@
 						<th>Pilot ID</th>
 						<th>Call Sign</th>
 						<th>Phonetic</th>
+						<th></th>
 						<th>Name</th>
 						</tr>
 				</thead>
@@ -385,6 +471,9 @@
 						<td>
 							<input type="text" class="form-control set_pilot_phonetic phonetic_{{ pilot.pilot_id }}" data-pilot_id="{{ pilot.pilot_id }}"
 							 value="{{ pilot.phonetic }}">
+						</td>
+						<td>
+							<button type="button" class="btn btn-default" id="speak_pilot" onclick="this.blur();" data-pilot_id="{{ pilot.pilot_id }}">&#9658;</button>
 						</td>
 						<td>
 							<input type="text" class="form-control set_pilot_name name_{{ pilot.pilot_id }}" data-pilot_id="{{ pilot.pilot_id }}" value="{{ pilot.name }}">


### PR DESCRIPTION
This adds "speak" buttons to the pilot entries on the Setting page so the pilot phonetic-names can be played for testing.  (This is a PR for the "feature-voice" branch.)

I ended up adding a 'speak()' function to the Settings page, so now there is one there and in the Race page.  I don't know if there's a good way to include a common copy of the 'speak()' function that both pages can use.

--ET