### PR TITLE
Phonetic time minutes / tenths mod

### DIFF
--- a/src/delta5server/server.py
+++ b/src/delta5server/server.py
@@ -801,14 +801,12 @@ def time_format(millis):
     return '{0:02d}:{1:02d}.{2:03d}'.format(minutes, seconds, milliseconds)
 
 def phonetictime_format(millis):
-    '''Convert milliseconds to 00:00.000'''
-    millis = int(millis)
-    minutes = millis / 60000
-    over = millis % 60000
-    seconds = over / 1000
-    over = over % 1000
-    milliseconds = over/10
-    return '{0:01d}.{1:02d}'.format(seconds, milliseconds)	
+    '''Convert milliseconds to phonetic'''
+    millis = int(millis + 50)  # round to nearest tenth of a second
+    seconds = millis / 1000
+    over = (millis % 60000) % 1000
+    tenths = over / 100
+    return '{0:01d}.{1:01d}'.format(seconds, tenths)
 	
 def pass_record_callback(node, ms_since_lap):
     '''Handles pass records from the nodes.'''


### PR DESCRIPTION
The current 'phonetictime_format(millis)' function ignores the "minutes" part of the time.  (Something like 1:23.456 gets called out as "23.45")

This mod makes it call out the total number of seconds; so, for example, 2:05 will be called out as 125 (seconds).  This mod also makes it call out only one digit of fractional time (rounded to the nearest tenth), for shorter announcements.  So, for example, 1:02.375 will be called out as "62.4"

--ET