### PR TITLE
Add channel/frequency labels to race page

### DIFF
--- a/src/delta5interface/Delta5Interface.py
+++ b/src/delta5interface/Delta5Interface.py
@@ -329,6 +329,15 @@ class Delta5Interface(BaseHardwareInterface):
             self.set_filter_ratio(node.index, filter_ratio)
         return self.filter_ratio
 
+    def intf_simulate_lap(self, node_index):
+        node = self.nodes[node_index]
+        node.current_rssi = 11
+        node.trigger_rssi = 22
+        node.peak_rssi_raw = 33
+        node.peak_rssi = 44
+        node.loop_time = 55
+        self.pass_record_callback(node, 100)
+
 def get_hardware_interface():
     '''Returns the delta 5 interface object.'''
     return Delta5Interface()

--- a/src/delta5server/server.py
+++ b/src/delta5server/server.py
@@ -204,7 +204,10 @@ def race():
                            current_heat=RACE.current_heat,
                            heats=Heat, pilots=Pilot,
                            fix_race_time=FixTimeRace.query.get(1).race_time_sec,
-						   lang_id=RACE.lang_id)
+						   lang_id=RACE.lang_id,
+        frequencies=[node.frequency for node in INTERFACE.nodes],
+        channels=[Frequency.query.filter_by(frequency=node.frequency).first().channel
+            for node in INTERFACE.nodes])
 
 @APP.route('/settings')
 @requires_auth
@@ -604,6 +607,13 @@ def on_delete_lap(data):
     server_log('Lap deleted: Node {0} Lap {1}'.format(node_index, lap_id))
     emit_current_laps() # Race page, update web client
     emit_leaderboard() # Race page, update web client
+
+@SOCKET_IO.on('simulate_lap')
+def on_simulate_lap(data):
+    '''Simulates a lap (for debug testing).'''
+    node_index = data['node']
+    server_log('Simulated lap: Node {0}'.format(node_index))
+    INTERFACE.intf_simulate_lap(node_index)
 
 # Socket io emit functions
 

--- a/src/delta5server/templates/race.html
+++ b/src/delta5server/templates/race.html
@@ -148,6 +148,14 @@
 			return false;
 		});
 
+		$('button#simulate_lap').click(function (event) {
+			var data = {
+				node: parseInt($(this).data('node')),
+			};
+			socket.emit('simulate_lap', data);
+			return false;
+		});
+
 		$(document).on("click", ".delete_lap", function (event) { // Needed for buttons added after document load
 			var data = {
 				node: parseInt($(this).data('node')),
@@ -298,6 +306,15 @@
 					{{ pilots.query.filter_by( pilot_id=heats.query.filter_by(heat_id=current_heat,node_index=node).first().pilot_id ).first().callsign
 					}}
 				</h4>
+			</div>
+			<div class="panel-heading">
+				<p class="panel-title">
+					<small>{{ channels[node] }} {{ frequencies[node] }}</small>
+				</p>
+				<!-- Comment-out <p></p> above and enable 'button' below to get simulate-lap buttons for debug testing -->
+				<!--
+				<button type="button" class="btn btn-default" id="simulate_lap" data-node="{{ node }}" onclick="this.blur();"><small>{{ channels[node] }} {{ frequencies[node] }}</small></button>
+				-->
 			</div>
 			<table class="table" id="current_laps_{{ node }}">
 				<thead>


### PR DESCRIPTION
This mod adds channel/frequency labels to the node columns on the Race page.  Also, code is in place so that with a simple edit to 'race.html' the labels turn into buttons that can be clicked on to simulate lap-pass events.  Very useful for debug testing.

--ET