### PR TITLE
Add 'Filter Ratio' to tuning parameters

### DIFF
--- a/doc/Tuning Parameters.md
+++ b/doc/Tuning Parameters.md
@@ -29,3 +29,6 @@ Adds a buffer around the fluctuating RSSI value during the first pass. Increase 
 
 ##### Trigger Threshold
 Increase this value if you get several pass records while passing the start gate. Lower this value if the quad has to travel very far before a passing event is triggered.
+
+##### Filter Ratio
+The Filter Ratio configures the amount of smoothing applied to the RSSI readings in the nodes. Values can range from 1 to 255, with a default value of 10. Lower values will result in more filtering and "smoother" readings.

--- a/src/delta5server/server.py
+++ b/src/delta5server/server.py
@@ -102,6 +102,7 @@ class Profiles(DB.Model):
     c_offset = DB.Column(DB.Integer, nullable=True)
     c_threshold = DB.Column(DB.Integer, nullable=True)
     t_threshold = DB.Column(DB.Integer, nullable=True)
+    f_ratio = DB.Column(DB.Integer, nullable=True)
 
 class LastProfile(DB.Model):
     id = DB.Column(DB.Integer, primary_key=True)
@@ -361,7 +362,8 @@ def on_add_profile():
                            description = 'New Profile %s' % max_profile_id,
                            c_offset=8,
                            c_threshold=90,
-                           t_threshold=40))
+                           t_threshold=40,
+                           f_ratio=10))
     DB.session.commit()
     on_set_profile(data={ 'profile': 'New Profile %s' % max_profile_id})
 
@@ -381,6 +383,7 @@ def on_delete_profile():
      INTERFACE.set_calibration_threshold_global(profile.c_threshold)
      INTERFACE.set_calibration_offset_global(profile.c_offset)
      INTERFACE.set_trigger_threshold_global(profile.t_threshold)
+     INTERFACE.set_filter_ratio_global(profile.f_ratio)
      emit_node_tuning()
 
 @SOCKET_IO.on('set_profile_name')
@@ -444,6 +447,20 @@ def on_set_trigger_threshold(data):
     server_log('Trigger threshold set: {0}'.format(trigger_threshold))
     emit_node_tuning()
 
+
+@SOCKET_IO.on('set_filter_ratio')
+def on_set_filter_ratio(data):
+    '''Set Filter Ratio.'''
+    filter_ratio = data['filter_ratio']
+    INTERFACE.set_filter_ratio_global(filter_ratio)
+    last_profile = LastProfile.query.get(1)
+    profile = Profiles.query.filter_by(id=last_profile.profile_id).first()
+    profile.f_ratio = filter_ratio
+    DB.session.commit()
+    server_log('Filter Ratio set: {0}'.format(filter_ratio))
+    emit_node_tuning()
+
+
 @SOCKET_IO.on('reset_database')
 def on_reset_database():
     '''Reset database.'''
@@ -473,6 +490,7 @@ def on_set_profile(data):
     INTERFACE.set_calibration_threshold_global(profile.c_threshold)
     INTERFACE.set_calibration_offset_global(profile.c_offset)
     INTERFACE.set_trigger_threshold_global(profile.t_threshold)
+    INTERFACE.set_filter_ratio_global(profile.f_ratio)
     emit_node_tuning()
     server_log("set tune paramas for profile '%s'" % profile_val)
 
@@ -649,6 +667,8 @@ def emit_node_tuning():
             tune_val.c_offset,
         'trigger_threshold': \
             tune_val.t_threshold,
+        'filter_ratio': \
+            tune_val.f_ratio,
         'profile_name':
             tune_val.name,
         'profile_description':
@@ -1035,17 +1055,20 @@ def db_reset_profile():
                              description ="default tune params for 25mW race",
                              c_offset=8,
                              c_threshold=65,
-                             t_threshold=40))
+                             t_threshold=40,
+                             f_ratio=10))
     DB.session.add(Profiles(name="default 200mW",
                              description ="default tune params for 200mW race",
                              c_offset=8,
                              c_threshold=90,
-                             t_threshold=40))
+                             t_threshold=40,
+                             f_ratio=10))
     DB.session.add(Profiles(name="default 600mW",
                              description ="default tune params for 600mW race",
                              c_offset=8,
                              c_threshold=100,
-                             t_threshold=40))
+                             t_threshold=40,
+                             f_ratio=10))
     DB.session.commit()
     server_log("Database set default profiles for 25,200,600 mW races")
 
@@ -1083,11 +1106,22 @@ if not os.path.exists('database.db'):
 db_reset_current_laps()
 
 # Send initial profile values to nodes
-last_profile = LastProfile.query.get(1)
-tune_val = Profiles.query.get(last_profile.profile_id)
+try:
+    last_profile = LastProfile.query.get(1)
+    tune_val = Profiles.query.get(last_profile.profile_id)
+except:
+    print 'Resetting tuning profiles (schema changed)'
+    Profiles.__table__.drop(DB.engine)  # update Profiles table schema
+    Profiles.__table__.create(DB.engine)
+    db_reset_profile()
+    last_profile = LastProfile.query.get(1)
+    tune_val = Profiles.query.get(last_profile.profile_id)
+    
+print 'Sending initial profile values to nodes'
 INTERFACE.set_calibration_threshold_global(tune_val.c_threshold)
 INTERFACE.set_calibration_offset_global(tune_val.c_offset)
 INTERFACE.set_trigger_threshold_global(tune_val.t_threshold)
+INTERFACE.set_filter_ratio_global(tune_val.f_ratio)
 
 
 # Test data - Current laps

--- a/src/delta5server/templates/settings.html
+++ b/src/delta5server/templates/settings.html
@@ -88,6 +88,7 @@
 			$('.set_calibration_threshold').val( msg.calibration_threshold);
 			$('.set_calibration_offset').val( msg.calibration_offset);
 			$('.set_trigger_threshold').val( msg.trigger_threshold);
+			$('.set_filter_ratio').val( msg.filter_ratio);
 			$('.set_profile_name').val( msg.profile_name);
 			$('.set_profile_description').val( msg.profile_description);
 
@@ -191,6 +192,14 @@
 			};
 			socket.emit('set_trigger_threshold', data);
 		})
+
+		$('.set_filter_ratio').change(function (event) {
+			var data = {
+				filter_ratio: parseInt($(this).val())
+			};
+			socket.emit('set_filter_ratio', data);
+		})
+
 		$('.set_profile_name').change(function (event) {
 			var data = {
 				profile_name: $(this).val()
@@ -563,6 +572,12 @@
 					<td><b>Trigger Threshold (Default 40)</b><br>Trigger minus Trigger Threshold ends normal pass</td>
 					<td>
 						<input type="text" class="form-control set_trigger_threshold">
+					</td>
+				</tr>
+				<tr>
+					<td><b>Filter Ratio (Default 10)</b><br>RSSI Filtering (lower for smoother readings)</td>
+					<td>
+						<input type="text" class="form-control set_filter_ratio">
 					</td>
 				</tr>
 			</table>


### PR DESCRIPTION
Adds 'Filter Ratio' as a new per-profile tuning parameter.

If the Profiles table in the current database does not have a filter-ratio column then the table is updated and the tuning profiles are reset to defaults.

--ET