### PR TITLE
Update CORS settings

### DIFF
--- a/src/timingserver/server.py
+++ b/src/timingserver/server.py
@@ -32,7 +32,7 @@ async_mode = "gevent"
 
 app = Flask(__name__, static_url_path='/static')
 app.config['SECRET_KEY'] = 'secret!'
-socketio = SocketIO(app, async_mode=async_mode)
+socketio = SocketIO(app, async_mode=async_mode, cors_allowed_origins='*')
 heartbeat_thread = None
 
 firmware_version = {'major': 0, 'minor': 1}


### PR DESCRIPTION
Allows connections to D5 server through more restrictive CORS defaults in Flask_SocketIO > 4.2